### PR TITLE
Add listener for whole section to be notified

### DIFF
--- a/statik/src/main/java/com/github/kittinunf/statik/dsl/DSL.kt
+++ b/statik/src/main/java/com/github/kittinunf/statik/dsl/DSL.kt
@@ -27,6 +27,8 @@ class SectionBuilder {
 
     private var footer: ItemRepresentable? = null
 
+    private var valueChangeListener: ((ItemRepresentable) -> Unit)? = null
+
     fun rows(vararg item: ItemRepresentable) {
         rows += item.asList()
     }
@@ -43,7 +45,14 @@ class SectionBuilder {
         footer = item
     }
 
-    fun build(): Section = Section(header, rows, footer)
+    fun onValueChangeListener(listener: (ItemRepresentable) -> Unit) {
+        valueChangeListener = listener
+    }
+
+    fun build(): Section =
+            Section(header, rows, footer).apply {
+                onValueInSectionChangedListener = valueChangeListener
+            }
 }
 
 class StatikBuilder {

--- a/statik/src/main/java/com/github/kittinunf/statik/dsl/DSL.kt
+++ b/statik/src/main/java/com/github/kittinunf/statik/dsl/DSL.kt
@@ -27,7 +27,7 @@ class SectionBuilder {
 
     private var footer: ItemRepresentable? = null
 
-    private var valueChangeListener: ((ItemRepresentable) -> Unit)? = null
+    private var valuesInSectionChangedListener: ((ItemRepresentable) -> Unit)? = null
 
     fun rows(vararg item: ItemRepresentable) {
         rows += item.asList()
@@ -45,13 +45,13 @@ class SectionBuilder {
         footer = item
     }
 
-    fun onValueChangeListener(listener: (ItemRepresentable) -> Unit) {
-        valueChangeListener = listener
+    fun onValuesInSectionChangedListener(listener: (ItemRepresentable) -> Unit) {
+        valuesInSectionChangedListener = listener
     }
 
     fun build(): Section =
             Section(header, rows, footer).apply {
-                onValueInSectionChangedListener = valueChangeListener
+                onValuesInSectionChangedListener = valuesInSectionChangedListener
             }
 }
 

--- a/statik/src/main/java/com/github/kittinunf/statik/model/Section.kt
+++ b/statik/src/main/java/com/github/kittinunf/statik/model/Section.kt
@@ -4,4 +4,7 @@ import com.github.kittinunf.statik.representable.ItemRepresentable
 
 data class Section(val header: ItemRepresentable? = null,
                    val rows: MutableList<ItemRepresentable>,
-                   val footer: ItemRepresentable? = null)
+                   val footer: ItemRepresentable? = null) {
+
+    var onValueInSectionChangedListener: ((ItemRepresentable) -> Unit)? = null
+}

--- a/statik/src/main/java/com/github/kittinunf/statik/model/Section.kt
+++ b/statik/src/main/java/com/github/kittinunf/statik/model/Section.kt
@@ -6,5 +6,5 @@ data class Section(val header: ItemRepresentable? = null,
                    val rows: MutableList<ItemRepresentable>,
                    val footer: ItemRepresentable? = null) {
 
-    var onValueInSectionChangedListener: ((ItemRepresentable) -> Unit)? = null
+    var onValuesInSectionChangedListener: ((ItemRepresentable) -> Unit)? = null
 }

--- a/statik/src/main/java/com/github/kittinunf/statik/representable/BaseRepresentable.kt
+++ b/statik/src/main/java/com/github/kittinunf/statik/representable/BaseRepresentable.kt
@@ -50,7 +50,7 @@ abstract class BaseRepresentable<T : Row<U>, U>(protected val item: T) : ItemRep
             onValueChangedListener?.invoke(item)
 
             if (::section.isInitialized)
-                section.onValueInSectionChangedListener?.invoke(this)
+                section.onValuesInSectionChangedListener?.invoke(this)
         }
     }
 }

--- a/statik/src/main/java/com/github/kittinunf/statik/representable/BaseRepresentable.kt
+++ b/statik/src/main/java/com/github/kittinunf/statik/representable/BaseRepresentable.kt
@@ -1,14 +1,36 @@
 package com.github.kittinunf.statik.representable
 
+import android.view.View
+import android.widget.TextView
 import com.github.kittinunf.statik.model.Row
 import com.github.kittinunf.statik.model.Section
 import com.github.kittinunf.statik.util.IdGenerator
 import kotlin.properties.Delegates
 
-typealias BaseItemRepresentable = BaseRepresentable<*, *>
+typealias OnValueChangedListener<T> = (T) -> Unit
 
-abstract class BaseRepresentable<T : Row<U>, U>(protected val item: T) : ItemRepresentable,
-        ViewSetupListener, ViewClickListener, ValueChangeListener<T> {
+typealias OnViewSetupListener = (View) -> Unit
+
+typealias OnClickListener = (View, Int) -> Unit
+
+typealias OnTextViewSetupListener = (TextView) -> Unit
+
+interface ViewSetupListener {
+    var onViewSetupListener: OnViewSetupListener?
+}
+
+interface ViewClickListener {
+    var onClickListener: OnClickListener?
+}
+
+interface ValueChangeListener<T> {
+    var onValueChangedListener: OnValueChangedListener<T>?
+}
+
+typealias AnyRepresentable = BaseRepresentable<*, *>
+
+abstract class BaseRepresentable<T : Row<U>, U>(protected val item: T) : ItemRepresentable, ValueChangeListener<T>,
+        ViewSetupListener, ViewClickListener {
 
     lateinit var section: Section
 
@@ -26,6 +48,9 @@ abstract class BaseRepresentable<T : Row<U>, U>(protected val item: T) : ItemRep
         if (old != new) {
             item.value = new
             onValueChangedListener?.invoke(item)
+
+            if (::section.isInitialized)
+                section.onValueInSectionChangedListener?.invoke(this)
         }
     }
 }

--- a/statik/src/main/java/com/github/kittinunf/statik/representable/InputRepresentable.kt
+++ b/statik/src/main/java/com/github/kittinunf/statik/representable/InputRepresentable.kt
@@ -23,5 +23,10 @@ class InputRowRepresentable : BaseRepresentable<InputRow, String>(InputRow()) {
 
     var error: String? = null
 
+    val isValid: Boolean
+        get() {
+            return onValidateInput?.invoke(text) ?: true
+        }
+
     override fun type(typeFactory: TypeFactory): Int = typeFactory.type(this)
 }

--- a/statik/src/main/java/com/github/kittinunf/statik/representable/ItemRepresentable.kt
+++ b/statik/src/main/java/com/github/kittinunf/statik/representable/ItemRepresentable.kt
@@ -1,33 +1,12 @@
 package com.github.kittinunf.statik.representable
 
-import android.view.View
-import android.widget.TextView
 import com.github.kittinunf.statik.adapter.TypeFactory
 
 interface ItemRepresentable {
+
     fun type(typeFactory: TypeFactory): Int
 
     val stableId: Long
 
     var position: Int
-}
-
-typealias OnValueChangedListener<T> = (T) -> Unit
-
-typealias OnViewSetupListener = (View) -> Unit
-
-typealias OnClickListener = (View, Int) -> Unit
-
-typealias OnTextViewSetupListener = (TextView) -> Unit
-
-interface ViewSetupListener {
-    var onViewSetupListener: OnViewSetupListener?
-}
-
-interface ViewClickListener {
-    var onClickListener: OnClickListener?
-}
-
-interface ValueChangeListener<T> {
-    var onValueChangedListener: OnValueChangedListener<T>?
 }


### PR DESCRIPTION
### What's this PR?

- [x] Add ability for the whole section to be notified. This should be easy for the consumer to watch the change when each row gets updated in the whole section layer.

#### Application

Consider

``` Kotlin
section.onValueInSectionChangedListener = {
  val isValid = section.rows.filterIsInstance<InputRowRepresentable>
   .map { it.isValid }
   .reduce { acc, each -> acc add each }
}
```

This snippet is to watch all InputRow state for the whole section whether it is valid or not.